### PR TITLE
Name change due to "similar name clash"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ TF Tabular is a project aimed at simplifying the process of handling tabular dat
 To get started with TF Tabular, you will need to install it using pip:
 
 ```sh
-pip install tf-tabular
+pip install tabular-tf
 ```
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["flit"]
 build-backend = "flit.buildapi"
 
 [project]
-name =  "tf-tabular"
+name =  "tabular-tf"
 authors = [
     {name = "Mathias Claassen", email = "mathias@xmartlabs.com"},
 ]


### PR DESCRIPTION
## Describe your changes

Rename library as it is installed from Pypi as "tf-tabular" is "too similar" to other libraries