### PR TITLE
Ignore tensorflow updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,17 +3,18 @@ updates:
   - package-ecosystem: pip
     directory: "/"
     schedule:
-      interval: daily
-      time: "07:00"
+      interval: weekly
     open-pull-requests-limit: 3
     allow:
       - dependency-type: direct
+    ignore:
+      - dependency-name: tensorflow
     commit-message:
       prefix: "update: "
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       time: "07:00"
     commit-message:
       prefix: "update: "

--- a/examples/movielens/movielens.ipynb
+++ b/examples/movielens/movielens.ipynb
@@ -29,13 +29,11 @@
     "import numpy as np\n",
     "import tensorflow as tf\n",
     "import tensorflow_datasets as tfds\n",
-    "import tensorflow_recommenders as tfrs\n",
     "\n",
     "from tensorflow.keras.layers import Dense\n",
     "from tensorflow.keras import Model\n",
     "\n",
     "from tf_tabular.builder import InputBuilder\n",
-    "from tf_tabular.utils import get_vocab\n",
     "from .movielens_model import MovielensModel"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ exclude = [
     ".git-rewrite",
     ".hg",
     ".ipynb_checkpoints",
-    ".ipynb",
     ".mypy_cache",
     ".nox",
     ".pants.d",
@@ -106,6 +105,7 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+exclude = ["*.ipynb"]
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ exclude = [
     ".git-rewrite",
     ".hg",
     ".ipynb_checkpoints",
+    ".ipynb",
     ".mypy_cache",
     ".nox",
     ".pants.d",


### PR DESCRIPTION
## Describe your changes

This ignores updates to TensorFlow as there were issues with TF 2.16. Thus sticking with 2.15 for now.
Also ignore linter checks in Jupyter notebooks