### PR TITLE
Change Dependabot update schedule to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: pip
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 3
     allow:
       - dependency-type: direct
@@ -14,7 +14,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
       time: "07:00"
     commit-message:
       prefix: "update: "


### PR DESCRIPTION
Changed the update schedule for pip and GitHub Actions from weekly to monthly.
